### PR TITLE
Fix datasource property panic

### DIFF
--- a/internal/provider/data_source_filesystem.go
+++ b/internal/provider/data_source_filesystem.go
@@ -59,7 +59,7 @@ func dataSourceFilesystemRead(ctx context.Context, d *schema.ResourceData, meta 
 	config := meta.(*Config)
 
 	filesystemName := d.Get("name").(string)
-	filesystem, err := describeDataset(config, filesystemName, getPropertyNames(d))
+	filesystem, err := describeDataset(config, filesystemName, []string{})
 
 	if filesystem == nil {
 		log.Println("[DEBUG] zfs filesystem does not exist!")

--- a/internal/provider/data_source_volume.go
+++ b/internal/provider/data_source_volume.go
@@ -39,7 +39,7 @@ func dataSourceVolumeRead(ctx context.Context, d *schema.ResourceData, meta inte
 	config := meta.(*Config)
 
 	volumeName := d.Get("name").(string)
-	volume, err := describeDataset(config, volumeName, getPropertyNames(d))
+	volume, err := describeDataset(config, volumeName, []string{})
 
 	if volume == nil {
 		log.Println("[DEBUG] zfs volume does not exist!")


### PR DESCRIPTION
This pull request fixes a panic that occurs when using datasources to read existing ZFS filesystems or volumes. The issue was caused by datasources incorrectly calling `getPropertyNames(d)`, which attempts to access a `property` schema field that only exists in resources and is nil on datasources, resulting in a panic when attempting a type assertion to `*schema.Set`. The fix replaces the `getPropertyNames(d)` call with an empty list `[]string{}` in all datasource read functions

Fixes #14
